### PR TITLE
Updated for Aspire Dashboard and telemetry collection

### DIFF
--- a/AskInsightsService/AskInsightsService.csproj
+++ b/AskInsightsService/AskInsightsService.csproj
@@ -7,5 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SpeechAnalyticsLibrary\SpeechAnalyticsLibrary.csproj" />
+    <ProjectReference Include="..\SpeechAnalytics.ServiceDefaults\SpeechAnalytics.ServiceDefaults.csproj" />
   </ItemGroup>
 </Project>

--- a/AskInsightsService/Program.cs
+++ b/AskInsightsService/Program.cs
@@ -4,8 +4,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using SpeechAnalyticsLibrary;
 using SpeechAnalyticsLibrary.Models;
+using SpeechAnalytics.ServiceDefaults;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.AddAppServiceDefaults();
 
 
 builder.Configuration
@@ -20,9 +23,6 @@ builder.Services.AddSingleton<AnalyticsSettings>(sp =>
     return settings;
 });
 
-builder.Logging.ClearProviders();
-builder.Logging.AddConsole();
-
 builder.Services.AddSingleton<IdentityHelper>();
 builder.Services.AddSingleton<FileHandling>();
 builder.Services.AddSingleton<CosmosHelper>();
@@ -33,6 +33,8 @@ builder.Services.AddHttpClient();
 builder.Services.AddRouting();
 
 var app = builder.Build();
+
+app.MapAppDefaultEndpoints();
 
 var logger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("AskInsightsService");
 var agentClient = app.Services.GetRequiredService<FoundryAgentClient>();

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This demo highlights the power of combining Microsoft [Microsoft Foundry](https:
 ![Architecture](images/Architecture.png)
 
 
+
 ### Deploying
 
 Deployment is automated using PowerShell, the [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/) and the [Azure Developer CLI](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/). These can be easily installed on a Windows machine using `winget`:
@@ -39,6 +40,7 @@ If successful, this process will create:
 - Azure Application Insights resource automatically connected to the Microsoft Foundry project for telemetry and monitoring
 - Azure Container Registry
 - Azure Container App Environment with 2 container apps: `transcription` and `ask`
+- [Aspire Dashboard](https://aspire.dev/dashboard/overview/) with logs and telemetry configured 
 - User and system assigned managed identities with all appropriate RBAC assignments
 - Log Analytics and App Insights
 - Event Grid and subscription to the Upload event on the `audio` storage container

--- a/SpeechAnalytics.AppHost/Program.cs
+++ b/SpeechAnalytics.AppHost/Program.cs
@@ -1,0 +1,11 @@
+using Aspire.Hosting;
+using Aspire.Hosting.Azure;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+// Application services
+var askInsights = builder.AddProject("askinsights", "../AskInsightsService/AskInsightsService.csproj");
+
+var transcription = builder.AddProject("transcription", "../TranscriptionService/TranscriptionService.csproj");
+
+builder.Build().Run();

--- a/SpeechAnalytics.AppHost/SpeechAnalytics.AppHost.csproj
+++ b/SpeechAnalytics.AppHost/SpeechAnalytics.AppHost.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+    <AspireHostingSDKVersion>9.0.0</AspireHostingSDKVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting" Version="13.1.0" />
+    <PackageReference Include="Aspire.Hosting.Azure" Version="13.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AskInsightsService\AskInsightsService.csproj" />
+    <ProjectReference Include="..\TranscriptionService\TranscriptionService.csproj" />
+  </ItemGroup>
+</Project>

--- a/SpeechAnalytics.ServiceDefaults/ServiceDefaultsExtensions.cs
+++ b/SpeechAnalytics.ServiceDefaults/ServiceDefaultsExtensions.cs
@@ -1,0 +1,78 @@
+using System.Reflection;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Http;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Resources;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Logs;
+using Azure.Monitor.OpenTelemetry.Exporter;
+
+namespace SpeechAnalytics.ServiceDefaults;
+
+public static class ServiceDefaultsExtensions
+{
+    public static IHostApplicationBuilder AddAppServiceDefaults(this IHostApplicationBuilder builder)
+    {
+        var serviceName = Assembly.GetEntryAssembly()?.GetName().Name ?? "service";
+        string? aiConnString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]
+            ?? builder.Configuration["APPINSIGHTS_CONNECTIONSTRING"];
+
+        builder.Services.AddOpenTelemetry()
+            .ConfigureResource(rb => rb.AddService(serviceName))
+            .WithTracing(tracing =>
+            {
+                tracing
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddOtlpExporter();
+                if (!string.IsNullOrWhiteSpace(aiConnString))
+                {
+                    tracing.AddAzureMonitorTraceExporter(o => o.ConnectionString = aiConnString);
+                }
+            })
+            .WithMetrics(metrics =>
+            {
+                metrics
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation()
+                    .AddOtlpExporter();
+                if (!string.IsNullOrWhiteSpace(aiConnString))
+                {
+                    metrics.AddAzureMonitorMetricExporter(o => o.ConnectionString = aiConnString);
+                }
+            });
+
+        builder.Services.AddLogging(lb =>
+        {
+            lb.AddOpenTelemetry(o =>
+            {
+                o.IncludeScopes = true;
+                o.ParseStateValues = true;
+                o.IncludeFormattedMessage = true;
+                o.AddOtlpExporter();
+                if (!string.IsNullOrWhiteSpace(aiConnString))
+                {
+                    o.AddAzureMonitorLogExporter(opt => opt.ConnectionString = aiConnString);
+                }
+            });
+        });
+
+        builder.Services.ConfigureHttpClientDefaults(http =>
+        {
+            http.AddStandardResilienceHandler();
+        });
+
+        builder.Services.AddHealthChecks();
+        return builder;
+    }
+
+    public static WebApplication MapAppDefaultEndpoints(this WebApplication app)
+    {
+        app.MapHealthChecks("/health");
+        return app;
+    }
+}

--- a/SpeechAnalytics.ServiceDefaults/SpeechAnalytics.ServiceDefaults.csproj
+++ b/SpeechAnalytics.ServiceDefaults/SpeechAnalytics.ServiceDefaults.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0" />
+  </ItemGroup>
+</Project>

--- a/SpeechAnalytics.sln
+++ b/SpeechAnalytics.sln
@@ -17,6 +17,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AskInsightsService", "AskIn
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TranscriptionService", "TranscriptionService\TranscriptionService.csproj", "{76020DD2-7131-4347-A417-25D92B8FA6BA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpeechAnalytics.AppHost", "SpeechAnalytics.AppHost\SpeechAnalytics.AppHost.csproj", "{1876C91E-7FBC-4A75-A2DC-EDE2811A7097}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpeechAnalytics.ServiceDefaults", "SpeechAnalytics.ServiceDefaults\SpeechAnalytics.ServiceDefaults.csproj", "{A979EEA8-2C4D-48B8-B1F2-9CC1522E5DD1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -75,6 +79,30 @@ Global
 		{76020DD2-7131-4347-A417-25D92B8FA6BA}.Release|x64.Build.0 = Release|Any CPU
 		{76020DD2-7131-4347-A417-25D92B8FA6BA}.Release|x86.ActiveCfg = Release|Any CPU
 		{76020DD2-7131-4347-A417-25D92B8FA6BA}.Release|x86.Build.0 = Release|Any CPU
+		{1876C91E-7FBC-4A75-A2DC-EDE2811A7097}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1876C91E-7FBC-4A75-A2DC-EDE2811A7097}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1876C91E-7FBC-4A75-A2DC-EDE2811A7097}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1876C91E-7FBC-4A75-A2DC-EDE2811A7097}.Debug|x64.Build.0 = Debug|Any CPU
+		{1876C91E-7FBC-4A75-A2DC-EDE2811A7097}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1876C91E-7FBC-4A75-A2DC-EDE2811A7097}.Debug|x86.Build.0 = Debug|Any CPU
+		{1876C91E-7FBC-4A75-A2DC-EDE2811A7097}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1876C91E-7FBC-4A75-A2DC-EDE2811A7097}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1876C91E-7FBC-4A75-A2DC-EDE2811A7097}.Release|x64.ActiveCfg = Release|Any CPU
+		{1876C91E-7FBC-4A75-A2DC-EDE2811A7097}.Release|x64.Build.0 = Release|Any CPU
+		{1876C91E-7FBC-4A75-A2DC-EDE2811A7097}.Release|x86.ActiveCfg = Release|Any CPU
+		{1876C91E-7FBC-4A75-A2DC-EDE2811A7097}.Release|x86.Build.0 = Release|Any CPU
+		{A979EEA8-2C4D-48B8-B1F2-9CC1522E5DD1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A979EEA8-2C4D-48B8-B1F2-9CC1522E5DD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A979EEA8-2C4D-48B8-B1F2-9CC1522E5DD1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A979EEA8-2C4D-48B8-B1F2-9CC1522E5DD1}.Debug|x64.Build.0 = Debug|Any CPU
+		{A979EEA8-2C4D-48B8-B1F2-9CC1522E5DD1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A979EEA8-2C4D-48B8-B1F2-9CC1522E5DD1}.Debug|x86.Build.0 = Debug|Any CPU
+		{A979EEA8-2C4D-48B8-B1F2-9CC1522E5DD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A979EEA8-2C4D-48B8-B1F2-9CC1522E5DD1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A979EEA8-2C4D-48B8-B1F2-9CC1522E5DD1}.Release|x64.ActiveCfg = Release|Any CPU
+		{A979EEA8-2C4D-48B8-B1F2-9CC1522E5DD1}.Release|x64.Build.0 = Release|Any CPU
+		{A979EEA8-2C4D-48B8-B1F2-9CC1522E5DD1}.Release|x86.ActiveCfg = Release|Any CPU
+		{A979EEA8-2C4D-48B8-B1F2-9CC1522E5DD1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TranscriptionService/Program.cs
+++ b/TranscriptionService/Program.cs
@@ -7,17 +7,17 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using SpeechAnalyticsLibrary;
 using SpeechAnalyticsLibrary.Models;
+using SpeechAnalytics.ServiceDefaults;
 using System.Text.Json;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.AddAppServiceDefaults();
 
 builder.Configuration
     .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
     .AddJsonFile("local.settings.json", optional: true, reloadOnChange: false)
     .AddEnvironmentVariables();
-
-builder.Logging.ClearProviders();
-builder.Logging.AddConsole();
 
 builder.Services.AddSingleton<AnalyticsSettings>(sp =>
 {
@@ -36,6 +36,8 @@ builder.Services.AddSingleton<TranscriptionProcessor>();
 builder.Services.AddHttpClient();
 
 var app = builder.Build();
+
+app.MapAppDefaultEndpoints();
 
 app.MapPost("/events", async (HttpRequest request, TranscriptionProcessor processor, ILoggerFactory loggerFactory) =>
 {

--- a/TranscriptionService/TranscriptionService.csproj
+++ b/TranscriptionService/TranscriptionService.csproj
@@ -11,5 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SpeechAnalyticsLibrary\SpeechAnalyticsLibrary.csproj" />
+    <ProjectReference Include="..\SpeechAnalytics.ServiceDefaults\SpeechAnalytics.ServiceDefaults.csproj" />
   </ItemGroup>
 </Project>

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -17,6 +17,9 @@ param embeddingDeploymentName string
 param askContainerImage string = 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
 param transcriptionContainerImage string = 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
 
+@description('Deploy Aspire dashboard container apps')
+param enableAspireDashboard bool = true
+
 param firstProvision bool = true
 
 var containerEnvironmentName = '${containerAppName}-env'
@@ -142,6 +145,7 @@ module containerApps 'containerapps.bicep' = {
         mangedIdentityClientId: managedIdentity.outputs.clientId
         foundryResourceId: aiFoundry.outputs.foundryResourceId
         foundryResourceName: aiFoundry.outputs.foundryResourceName
+        enableAspireDashboard: enableAspireDashboard
     }
     dependsOn: [
         permissionsacr

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -52,6 +52,9 @@
     },
     "firstProvision": {
       "value": "${FIRST_PROVISION}"
+    },
+    "enableAspireDashboard": {
+      "value": true
     }
   }
 }


### PR DESCRIPTION
This pull request introduces Aspire Dashboard support and standardizes service defaults across the solution, focusing on improved observability, configuration, and deployment automation. The changes add new infrastructure for the Aspire Dashboard, centralize OpenTelemetry and Azure Monitor configuration in a shared library, and update both the application code and infrastructure scripts to use these enhancements.

Key changes include:

**Aspire Dashboard Integration:**

- Added deployment of Aspire Dashboard UI and OTLP ingress as container apps, with configuration and outputs for easy access and monitoring. This includes new resources in `containerapps.bicep` and corresponding outputs for dashboard endpoints. [[1]](diffhunk://#diff-9224f57b58de5e705e9a44786aceeeb2524c6117a3cc599619c8c0ee0b8295b3R28-R80) [[2]](diffhunk://#diff-9224f57b58de5e705e9a44786aceeeb2524c6117a3cc599619c8c0ee0b8295b3R314-R411) [[3]](diffhunk://#diff-9224f57b58de5e705e9a44786aceeeb2524c6117a3cc599619c8c0ee0b8295b3R421-R426) [[4]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R20-R22) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R43)

**Service Defaults and Observability:**

- Introduced a new `SpeechAnalytics.ServiceDefaults` project that provides extension methods to configure OpenTelemetry tracing, metrics, logging, Azure Monitor exporters, HTTP resilience, and health checks in a consistent way across services. [[1]](diffhunk://#diff-347c184551ed6e7dbb0702638c37d80ab170c6a45d3c8222055ffdb34c0de579R1-R16) [[2]](diffhunk://#diff-b44d6e85d99f8731690b7df2c7756c41c051dc02b7f1c7d92cef4ac55cc6efb0R1-R78)
- Updated `AskInsightsService` and `TranscriptionService` to consume the new service defaults, removing manual logging setup and adding health check endpoints. [[1]](diffhunk://#diff-88e744d06542e6bc201b6db6e0dc99a83021d949570711c23346f6e8c1d3d99eR10) [[2]](diffhunk://#diff-bcc006498920834b2f0e8b6c1cacc1547a0987188f136718be337da46c29f2ecR14) [[3]](diffhunk://#diff-d99ca715cc1c24d3a7e1d8302de901fe9c43e2c909791de292ee09dd41a5b367R7-R12) [[4]](diffhunk://#diff-d99ca715cc1c24d3a7e1d8302de901fe9c43e2c909791de292ee09dd41a5b367L23-L25) [[5]](diffhunk://#diff-d99ca715cc1c24d3a7e1d8302de901fe9c43e2c909791de292ee09dd41a5b367R37-R38) [[6]](diffhunk://#diff-147e5b35e371593f7927852ede97054778da52b8773d80a32b5485b1fc6d6ef5R10-L21) [[7]](diffhunk://#diff-147e5b35e371593f7927852ede97054778da52b8773d80a32b5485b1fc6d6ef5R40-R41)

**Infrastructure and Configuration Enhancements:**

- Improved container app environment configuration to enable OpenTelemetry integration with Azure Application Insights and Log Analytics, and added support for dynamic JSON columns.
- Ensured both `APPINSIGHTS_CONNECTIONSTRING` and `APPLICATIONINSIGHTS_CONNECTION_STRING` are set as environment variables for compatibility. [[1]](diffhunk://#diff-9224f57b58de5e705e9a44786aceeeb2524c6117a3cc599619c8c0ee0b8295b3L169-R187) [[2]](diffhunk://#diff-9224f57b58de5e705e9a44786aceeeb2524c6117a3cc599619c8c0ee0b8295b3L205-R221) [[3]](diffhunk://#diff-9224f57b58de5e705e9a44786aceeeb2524c6117a3cc599619c8c0ee0b8295b3L268-R284)

**Solution and Project Structure:**

- Added new projects to the solution file: `SpeechAnalytics.AppHost` (for distributed application orchestration) and `SpeechAnalytics.ServiceDefaults`. [[1]](diffhunk://#diff-27b386add46ee2ce2a906cd55131f99aedca0e4faef380e51abc1621d94435a1R20-R23) [[2]](diffhunk://#diff-27b386add46ee2ce2a906cd55131f99aedca0e4faef380e51abc1621d94435a1R82-R105)
- Added initial implementation of `SpeechAnalytics.AppHost` to orchestrate service projects using Aspire Hosting. [[1]](diffhunk://#diff-8adbfc327d842470a926a5b0d0f7bd7367d2229e793c3f3dbdb30824232f05e1R1-R18) [[2]](diffhunk://#diff-2a34ada36e1e4c4ab494b20b66160f80e50591f594f4e96f4c8a96ce3e1bae2cR1-R11)

**Documentation Updates:**

- Updated the `README.md` to mention Aspire Dashboard as part of the deployed resources. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R7) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R43)