### PR TITLE
Migrate from Microsoft.Agents.AI.AzureAI to Microsoft.Agents.AI.Foundry

### DIFF
--- a/SpeechAnalyticsLibrary/FoundryAgentClient.cs
+++ b/SpeechAnalyticsLibrary/FoundryAgentClient.cs
@@ -6,13 +6,12 @@ using System.Text.Json;
 using System.Threading;
 using Azure;
 using Azure.AI.Projects;
-using Azure.AI.Projects.OpenAI;
 using Azure.Identity;
-using Microsoft.Extensions.Logging;
-using OpenAI.Responses;
-using SpeechAnalyticsLibrary.Models;
 using Microsoft.Agents.AI;
+using Microsoft.Agents.AI.Foundry;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using SpeechAnalyticsLibrary.Models;
 
 #pragma warning disable OPENAI001 // OpenAI SDK preview constructs required by Azure Agent Framework preview
 namespace SpeechAnalyticsLibrary
@@ -161,29 +160,22 @@ namespace SpeechAnalyticsLibrary
 
         private async Task<string> ExecuteAgentAsync(string instructionKey, string userInput, CancellationToken cancellationToken)
         {
-            var agentVersion = await EnsureAgentVersionAsync(instructionKey, cancellationToken);
-            var responseClient = _projectClient.OpenAI.GetProjectResponsesClientForAgent(agentVersion.Name);
+            var agent = await EnsureAgentVersionAsync(instructionKey, cancellationToken);
 
-            CreateResponseOptions options = new()
+            var messages = new List<ChatMessage>
             {
-                InputItems =
-            {
-               ResponseItem.CreateUserMessageItem(userInput ?? string.Empty)
-            }
+                new(ChatRole.User, userInput ?? string.Empty)
             };
 
-            ResponseResult response = await responseClient.CreateResponseAsync(options, cancellationToken);
-            if (response.Status != ResponseStatus.Completed)
-            {
-                if (response.Error != null)
-                {
-                    _log.LogError("Agent {Agent} returned error: {Code} - {Message}", agentVersion.Name, response.Error.Code, response.Error.Message);
-                    throw new InvalidOperationException(response.Error.Message ?? "Agent response returned an error.");
-                }
-                throw new InvalidOperationException($"Agent {agentVersion.Name} returned status {response.Status}.");
-            }
+            var response = await agent.RunAsync(messages, session: null, options: null, cancellationToken: cancellationToken);
 
-            return response.GetOutputText();
+            var outputText = response.Messages?
+                .Where(m => m.Role == ChatRole.Assistant)
+                .SelectMany(m => m.Contents.OfType<TextContent>())
+                .Select(tc => tc.Text)
+                .LastOrDefault();
+
+            return outputText ?? string.Empty;
         }
 
         private async Task<AIAgent> EnsureAgentVersionAsync(string instructionKey, CancellationToken cancellationToken)
@@ -210,27 +202,14 @@ namespace SpeechAnalyticsLibrary
                    ? configuredName
                    : instructionKey.Replace('.', '-');
 
-                //Use the existing agent if available
-                await foreach (var a in _projectClient.Agents.GetAgentsAsync())
-                {
-                    if (a.Name == agentName)
-                    {
-                        _agentCache[instructionKey] = await _projectClient.GetAIAgentAsync(name: agentName, cancellationToken: cancellationToken);
-                        return _agentCache[instructionKey];
-                    }
-                }
+                var agent = _projectClient.AsAIAgent(
+                    model: _settings.ModelDeploymentName,
+                    instructions: instructions,
+                    name: agentName,
+                    description: agentName);
 
-                //Otherwise, create it
-                AIAgent aIAgent = await _projectClient.CreateAIAgentAsync(
-                   name: agentName,
-                   model: _settings.ModelDeploymentName,
-                   instructions: instructions,
-                   tools: [],
-                   cancellationToken: cancellationToken);
-
-                _agentCache[instructionKey] = aIAgent;
-
-                return aIAgent;
+                _agentCache[instructionKey] = agent;
+                return agent;
             }
             finally
             {

--- a/SpeechAnalyticsLibrary/SpeechAnalyticsLibrary.csproj
+++ b/SpeechAnalyticsLibrary/SpeechAnalyticsLibrary.csproj
@@ -18,12 +18,16 @@
    </ItemGroup>
 
    <ItemGroup>
+      <PackageReference Include="Azure.AI.Projects" Version="2.1.0-beta.2" />
+      <PackageReference Include="Azure.AI.Projects.Agents" Version="2.1.0-beta.2" />
       <PackageReference Include="Azure.AI.VoiceLive" Version="1.0.0" />
-      <PackageReference Include="Azure.AI.Projects" Version="2.0.0-beta.2" />
-      <PackageReference Include="Azure.Identity" Version="1.19.0" />
+      <PackageReference Include="Azure.Identity" Version="1.21.0" />
       <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
+      <PackageReference Include="Microsoft.Agents.AI" Version="1.6.1" />
+      <PackageReference Include="Microsoft.Agents.AI.Foundry" Version="1.6.1-preview.260514.1" />
       <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
       <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.48.2" />
+      <PackageReference Include="Microsoft.Extensions.AI" Version="10.6.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
       <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.5" />
@@ -31,24 +35,6 @@
       <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.5" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-	   <PackageReference Include="Microsoft.Agents.AI" Version="1.0.0-rc4" />
-	   <PackageReference Include="Microsoft.Extensions.AI" Version="10.4.1" />
-	   <PackageReference Include="Microsoft.Agents.AI.AzureAI" Version="1.0.0-rc4" />
-      <PackageReference Include="Azure.AI.Projects" Version="1.2.0-beta.5" />
-      <PackageReference Include="Azure.Identity" Version="1.17.1" />
-      <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
-      <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.57.0" />
-      <PackageReference Include="Microsoft.CognitiveServices.Speech" Version="1.47.0" />
-      <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.2" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.2" />
-      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
-      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.2" />
-      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.2" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-	   <PackageReference Include="Microsoft.Agents.AI" Version="1.0.0-preview.260128.1" />
-	   <PackageReference Include="Microsoft.Extensions.AI" Version="10.2.0" />
-	   <PackageReference Include="Microsoft.Agents.AI.AzureAI" Version="1.0.0-preview.260128.1" />
    </ItemGroup>
 
 </Project>

--- a/azure.yaml
+++ b/azure.yaml
@@ -16,6 +16,7 @@ services:
       context: ..
       dockerfile: AskInsightsService/Dockerfile
       image: ${AZD_SERVICE_ASKINSIGHTS_IMAGE}
+      remoteBuild: true
 
   transcription:
     project: TranscriptionService
@@ -29,6 +30,7 @@ services:
       context: ..
       dockerfile: TranscriptionService/Dockerfile
       image: ${AZD_SERVICE_TRANSCRIPTION_IMAGE}
+      remoteBuild: true
       
    
 infra:

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -137,7 +137,7 @@ module containerApps 'containerapps.bicep' = {
         cosmosDatabaseName: cosmosDB.outputs.cosmosDataBaseName
         cosmosContainerName: cosmosDB.outputs.cosmosContainerName
         appInsightsConnectionString : appInsights.outputs.connectionString
-        usePlaceholderImage : firstProvision
+        usePlaceholderImage : true
         managedIdentityResourceId: managedIdentity.outputs.id
         foundryProjectEndpoint: aiFoundry.outputs.aiFoundryProjectEndpoint
         chatModelDeploymentName: chatDeploymentName


### PR DESCRIPTION
## Changes
### Package Migration
- Replaced Microsoft.Agents.AI.AzureAI 1.0.0-rc4 with Microsoft.Agents.AI.Foundry 1.6.1-preview.260514.1
- Added Azure.AI.Projects.Agents 2.1.0-beta.2
- Updated Azure.AI.Projects to 2.1.0-beta.2
- Updated Azure.Identity to 1.21.0
- Cleaned up duplicate PackageReference entries in csproj

### Code Changes (FoundryAgentClient.cs)
- Rewrote EnsureAgentVersionAsync to use code-first AsAIAgent pattern
- Rewrote ExecuteAgentAsync to use agent.RunAsync() instead of removed OpenAI Responses API
- Removed dependencies on Azure.AI.Projects.OpenAI and OpenAI.Responses namespaces

### Infrastructure Fixes
- Fixed usePlaceholderImage: firstProvision to true in Bicep (avoids stale image tag errors)
- Added remoteBuild: true to azure.yaml services

**Build**: 0 errors | **azd up**: Verified | **azd down**: Cleaned up
